### PR TITLE
drop juju/errors dep

### DIFF
--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -6,7 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/errors"
+	"errors"
+
 	"github.com/zanmato1984/clickhouse/lib/binary"
 )
 
@@ -26,7 +27,7 @@ func (d *Decimal) Write(encoder *binary.Encoder, v interface{}) error {
 	case []byte:
 		_, err := encoder.Write(value)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		return nil
 	default:
@@ -45,11 +46,11 @@ func parseDecimal(name, chType string) (*Decimal, error) {
 	splits := strings.Split(s, ",")
 	precision, err := strconv.Atoi(splits[0])
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	scale, err := strconv.Atoi(splits[1])
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &Decimal{
 		base: base{

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -1,12 +1,11 @@
 package column
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
-
-	"errors"
 
 	"github.com/zanmato1984/clickhouse/lib/binary"
 )


### PR DESCRIPTION
drop juju/errors dep, so TiDB-Binlog can drop this dep, just use standard `errors` package like other place in this lib